### PR TITLE
Load ncurses after the source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all:
-	g++ -std=c++14 -lncurses fireplace.cpp -o fireplace
+	g++ -std=c++14 fireplace.cpp -lncurses -o fireplace


### PR DESCRIPTION
If the library is loaded first, the compiler might not correctly link all the function