### PR TITLE
Makefile: make it installable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,13 @@
+DESTDIR ?= $(HOME)
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+
 all:
 	g++ -std=c++14 main.cpp -lncurses -O3 -o fireplace
+
+install:
+	install -d $(DESTDIR)/$(BINDIR)
+	install -m 755 fireplace $(DESTDIR)/$(BINDIR)
+
+uninstall:
+	rm $(DESTDIR)/$(BINDIR)/fireplace


### PR DESCRIPTION
First off, this program is so lit :fire: 

This PR makes it easier to package. by addingf recipes for `install` and `uninstall`.

This uses standard packaging conventions so that it can easily be packaged for linux distributions.

----

You can see this in action with the openSUSE build here:

https://build.opensuse.org/package/show/home:avindra/fireplace