### PR TITLE
remove ncurses COLORS printout in help message

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -321,7 +321,6 @@ int main(int argc, char** argv)
                 break;
             case 'h':
                 printhelp(argv[0]);
-                std::cout << COLORS <<std::endl;
                 return 0;
             case 'f':
                 if (atoi(optarg) < 1) framerate = 0;


### PR DESCRIPTION
I believe it was for debugging and somehow left in the commit, but if I am mistaken and it's printed by intention, just close this PR.