### PR TITLE
optimize new state bit copying

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -202,7 +202,7 @@ void wolfram(int* world, const int rule)
         c = world[i];
         r = world[ridx];
         current = (l<<2) | (c<<1) | r;
-        next[i] = ((1<<current) & rule) > 0 ? 1 : 0;
+        next[i] = (rule>>current) & 0b1;
     }
 
     for (int i = 0; i < WIDTH; i++) {


### PR DESCRIPTION
Instead of shifting bit index to bitwise AND rule number, this shifts
the bit in rule number down.  It uses just one bitwise shift and one AND
without needing a ternary operation as previous does.