### PR TITLE
fix: add support for MacOS

### DIFF
--- a/main.c
+++ b/main.c
@@ -292,7 +292,7 @@ loop:
         nextframe(field, count, hotplate);
         #ifdef _WIN32
             Sleep(frameperiod);
-        #elif __linux__
+        #elif __linux__ || __APPLE__
             usleep(frameperiod);
         #endif
     }


### PR DESCRIPTION
Subtitled: **the fire never sleeps**

This pull request includes a small change to the `main.c` file. The change ensures compatibility with macOS by modifying the conditional compilation directive for the `usleep` function.

* [`main.c`](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecL295-R295): Added `__APPLE__` to the conditional compilation directive for the `usleep` function to ensure compatibility with macOS.